### PR TITLE
修復幾個 Github 渲染 org 文件時的格式問題

### DIFF
--- a/04-關於key-binding的兩三事.org
+++ b/04-關於key-binding的兩三事.org
@@ -44,7 +44,7 @@ Symbol 是 Lisp、Ruby、Julia 等語言中有的一種資料型態，目前不�
     (define-key twittering-mode-map (kbd "U") ’ twittering-user-timeline)
     #+END_SRC
 
-    *各個 mode 儲存 key-bindings 的變數一律是 「該 mode 的正式名稱 + =-map= 」* 。例如名稱叫 =twittering-mode=  的 major mode，他的 key-map 就是 =twittering-mode-map= 。這是規則，記下來就對了。
+    *各個 mode 儲存 key-bindings 的變數一律是 「該 mode 的正式名稱 +* =-map= *」* 。例如名稱叫 =twittering-mode=  的 major mode，他的 key-map 就是 =twittering-mode-map= 。這是規則，記下來就對了。
 
     #+BEGIN_QUOTE
     查 mode 的正式名稱最快的方式：
@@ -86,10 +86,10 @@ Symbol 是 Lisp、Ruby、Julia 等語言中有的一種資料型態，目前不�
 
 ** Prefix Key (=C-x= & =C-c=)
 =C-x= 與 =C-c= 是前綴(prefix)組合鍵，有特殊意義：
-1. *你無法單獨使用 Prefix key（例如你無法把某個功能綁到只按一個 =C-x= 就能達成，當你試圖這樣綁定時它會報錯）。*
+1. *你無法單獨使用 Prefix key（例如你無法把某個功能綁到只按一個* =C-x= *就能達成，當你試圖這樣綁定時它會報錯）。*
 2. 反過來說，「預設情況下」，你也無法用這兩個以外的按鍵當作 Prefix key ，例如把某個功能綁定到 =C-s C-k= 或 =C-d m= 。
 
-3. 靠著 Prefix key，你可以綁任意「深度」的 combo「組合技」、「連續技」，例如只要你爽（或者夠無聊），你也可以把查[[https://github.com/kuanyui/moedict.el][萌典]] 的命令綁到 =C-x 上 上 下 下 左 右 左 右 a b= ，只要他沒跟任何現有key-binding衝突即可。
+3. 靠著 Prefix key，你可以綁任意「深度」的 combo「組合技」、「連續技」，例如只要你爽（或者夠無聊），你也可以把查 [[https://github.com/kuanyui/moedict.el][萌典]] 的命令綁到 =C-x 上 上 下 下 左 右 左 右 a b= ，只要他沒跟任何現有key-binding衝突即可。
 
 #+BEGIN_SRC elisp
 (global-set-key (kbd "C-x <up> <up> <down> <down> <left> <right> <left> <right> a b") 'moedict)

--- a/05-設定檔相關的基本概念.org
+++ b/05-設定檔相關的基本概念.org
@@ -54,7 +54,7 @@ Emacs 是個非常吃重設定檔的編輯器，這一篇會為您解答最常�
     - =C-h v= =minor-mode-list= 查詢目前 buffer 下所有啟動的 minor mode 的正式名稱
     #+END_QUOTE
 
-    *各個 mode 儲存 hook 的變數名稱一律是 「該 mode 的正式名稱 + =-hook= 」* ，例如想要在 =python-mode= 啟動時順便打開 =highlight-symbol-mode= ：
+    *各個 mode 儲存 hook 的變數名稱一律是 「該 mode 的正式名稱 +* =-hook= *」* ，例如想要在 =python-mode= 啟動時順便打開 =highlight-symbol-mode= ：
 
 #+BEGIN_SRC elisp
     (add-hook 'python-mode-hook 'highlight-symbol-mode)

--- a/06-安裝套件入門.org
+++ b/06-安裝套件入門.org
@@ -12,7 +12,7 @@
 透過 =package.el= 安裝的套件會被放在 =~/.emacs.d/elpa/= 下。如果你用 git 管理你的 Emacs 設定檔，建議直接把 =~/.emacs.d/elpa/= 也一起放進去，先不要考慮什麼為了省空間而用 Emacs Lisp 寫個自動從網路上抓 packages 的 function 之類的，因為很容易 dependancies 爆掉，與其那麼麻煩不如先全部放。
 
 #+BEGIN_QUOTE
-也可以使用 =use-package= 這個插件的 =ensure= 選項來自動檢查並安裝未安裝的包。比如： =(use-package magit :ensure t)= 。
+如果你有使用 =use-package= 這個第三方外掛來管理套件，有個 =ensure= 選項可以自動檢查並安裝未安裝的套件。比如： =(use-package magit :ensure t)= 。
 
 -- 9m9
 #+END_QUOTE

--- a/06-安裝套件入門.org
+++ b/06-安裝套件入門.org
@@ -11,6 +11,12 @@
 
 透過 =package.el= 安裝的套件會被放在 =~/.emacs.d/elpa/= 下。如果你用 git 管理你的 Emacs 設定檔，建議直接把 =~/.emacs.d/elpa/= 也一起放進去，先不要考慮什麼為了省空間而用 Emacs Lisp 寫個自動從網路上抓 packages 的 function 之類的，因為很容易 dependancies 爆掉，與其那麼麻煩不如先全部放。
 
+#+BEGIN_QUOTE
+也可以使用 =use-package= 這個插件的 =ensure= 選項來自動檢查並安裝未安裝的包。比如： =(use-package magit :ensure t)= 。
+
+-- 9m9
+#+END_QUOTE
+
 *** 設定 MELPA
 Emacs 預設只有設定 GNU ELPA，這裡推薦可以加入 MELPA repository，這應該是目前最大的 Emacs package repository，方法也很簡單，在 =~/.emacs.d/init.el= 中加入下面這幾行就好：
 


### PR DESCRIPTION
改了兩個格式問題：

![1](https://user-images.githubusercontent.com/45503783/50235161-3785df00-03f2-11e9-877b-8179299b0802.png)

![1](https://user-images.githubusercontent.com/45503783/50235199-4bc9dc00-03f2-11e9-8a51-6ec83018c545.png)

追加了一個空格：

![1](https://user-images.githubusercontent.com/45503783/50235234-64d28d00-03f2-11e9-963f-9933657e95e5.png)
